### PR TITLE
Updated popover content to fit inside its region (WIP)

### DIFF
--- a/src/app/components/tissues-browser-grid/tissues-browser-grid.component.scss
+++ b/src/app/components/tissues-browser-grid/tissues-browser-grid.component.scss
@@ -23,6 +23,10 @@ $height-width-ratio: $item-min-height / $item-min-width;
         &.bs-popover-right {
           margin-left: 0;
         }
+
+        .popover-body {
+          line-height: normal;
+        }
       }
 
       @for $n from 1 through $num-column-classes {


### PR DESCRIPTION
This is not a complete fix. Better specifications are needed for what happens when there are too much metadata than can nicely fit inside the popover.