### PR TITLE
Updated the hubmap logo to open the hubmap site in a new window/tab

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -1,6 +1,8 @@
 <div class="ccf-toolbar wrapper">
   <div class="container">
-    <mat-icon class="icon svg-icon logo" svgIcon="app:hubmap-logo"></mat-icon>
+    <a href="https://hubmapconsortium.org/" target="_blank" rel="noreferrer noopener">
+      <mat-icon class="icon svg-icon logo" svgIcon="app:hubmap-logo"></mat-icon>
+    </a>
 
     <div class="item about" (mouseover)="isAboutItemHovered = true" (mouseout)="isAboutItemHovered = false" (click)=openAboutModal()>
       <mat-icon *ngIf="!isAboutItemHovered; else hoveredAboutIcon" class="icon font-icon">info_outline</mat-icon>


### PR DESCRIPTION
Issue - #12 

Description of changes - 
Clicking the hubmap logo now opens the hubmap site

TO-DO checklist before submitting your pull-request - 

- [ ] Are all acceptance criteria met ? 
- [ ] Has the code been documented properly ?
- [ ] Does component css-class structure conform to the Blue Dino style template i.e. top-level element .wrapper, .container and other inside css classes ?
- [ ] Have all checks passed ?
- [ ] Have you tested inter-browser functionality (should work on the latest Chrome, Firefox and Edge browsers) ?
