### PR TITLE
made drawer animations quicker

### DIFF
--- a/projects/ccf-eui/src/app/shared/components/drawer/content/content.component.scss
+++ b/projects/ccf-eui/src/app/shared/components/drawer/content/content.component.scss
@@ -6,7 +6,7 @@
 
   &.cff-drawer-content-animations {
     transition: {
-      duration: 1.5s;
+      duration: .5s;
       timing-function: ease-in-out;
       property: margin-left, margin-right;
     }

--- a/projects/ccf-eui/src/app/shared/components/drawer/drawer/drawer.component.ts
+++ b/projects/ccf-eui/src/app/shared/components/drawer/drawer/drawer.component.ts
@@ -77,7 +77,7 @@ class InitializationState {
       state('closed', style({ })),
 
       transition('closed => open-instant', animate(0)),
-      transition('closed <=> open, open-instant => closed', animate('1.5s ease-in-out'))
+      transition('closed <=> open, open-instant => closed', animate('.5s ease-in-out'))
     ]),
     trigger('expandCollapse', [
       state('collapsed', style({})),
@@ -91,7 +91,7 @@ class InitializationState {
         width: 'calc(100% - {{ margin }}px - {{ margin2 }}px)'
       }), EXPAND_COLLAPSE_PARAMS_DEFAULT),
 
-      transition('* <=> *', animate('1.5s ease-in-out'))
+      transition('* <=> *', animate('.5s ease-in-out'))
     ])
   ],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/ccf-rui/src/app/shared/components/drawer/content/content.component.scss
+++ b/projects/ccf-rui/src/app/shared/components/drawer/content/content.component.scss
@@ -6,7 +6,7 @@
 
   &.cff-drawer-content-animations {
     transition: {
-      duration: 1.5s;
+      duration: .5s;
       timing-function: ease-in-out;
       property: margin-left, margin-right;
     }

--- a/projects/ccf-rui/src/app/shared/components/drawer/drawer/drawer.component.ts
+++ b/projects/ccf-rui/src/app/shared/components/drawer/drawer/drawer.component.ts
@@ -77,7 +77,7 @@ class InitializationState {
       state('closed', style({ })),
 
       transition('closed => open-instant', animate(0)),
-      transition('closed <=> open, open-instant => closed', animate('1.5s ease-in-out'))
+      transition('closed <=> open, open-instant => closed', animate('.5s ease-in-out'))
     ]),
     trigger('expandCollapse', [
       state('collapsed', style({})),
@@ -91,7 +91,7 @@ class InitializationState {
         width: 'calc(100% - {{ margin }}px - {{ margin2 }}px)'
       }), EXPAND_COLLAPSE_PARAMS_DEFAULT),
 
-      transition('* <=> *', animate('1.5s ease-in-out'))
+      transition('* <=> *', animate('.5s ease-in-out'))
     ])
   ],
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
Reduced drawer and content.component animations from 1.5s to .5s. Issue #313 