### PR TITLE
info-button sizing

### DIFF
--- a/projects/ccf-rui/src/app/modules/info/info-button/info-button.component.scss
+++ b/projects/ccf-rui/src/app/modules/info/info-button/info-button.component.scss
@@ -1,4 +1,6 @@
 .ccf-info-button {
   cursor: pointer;
   transition: color 1s;
+  font-size: 2rem;
+  vertical-align: sub;
 }


### PR DESCRIPTION
Updated info button sizing, and aligned it.  Logo bar is already 4rem, and Hubmap icon / text are already 2rem.

Issue #309 