### PR TITLE
Pbi 568 rui updates

### DIFF
--- a/projects/ccf-rui/src/app/app.component.html
+++ b/projects/ccf-rui/src/app/app.component.html
@@ -14,7 +14,7 @@
     <div [class.closed]="!open" class="selector-drawer">
         <ccf-organ-selector #organSelector [organList]="organList" (organsChanged)="model.setOrgan($event[0])"
           [selectedOrgans]="[model.organ$ | async]" [class.closed]="!open"></ccf-organ-selector>
-          <div  class="expand-collapse-icon" >
+          <div class="expand-collapse-icon" >
             <mat-icon aria-hidden="false" aria-label="Close carousel drawer" (click)="open = !open">
               {{ open ? 'arrow_drop_up': 'arrow_drop_down' }}
             </mat-icon>

--- a/projects/ccf-rui/src/app/app.component.scss
+++ b/projects/ccf-rui/src/app/app.component.scss
@@ -39,7 +39,7 @@
           height: 1.2rem;
           position: absolute; 
           bottom: 0; 
-          right: 50%; 
+          right: calc(50% - 1.5rem);
           margin-bottom: -1.2rem; 
           z-index : 100;
           display: flex;
@@ -49,6 +49,7 @@
           background-color: white;
           border-bottom-left-radius: 0.2rem;
           border-bottom-right-radius: 0.2rem;
+          transition: 0.6s;
 
           &:hover {
             background-color: #ececec;

--- a/projects/ccf-rui/src/app/modules/left-sidebar/left-sidebar.component.scss
+++ b/projects/ccf-rui/src/app/modules/left-sidebar/left-sidebar.component.scss
@@ -79,6 +79,7 @@
         .expansion-content {
           margin-bottom: 0.75rem;
           text-align: center;
+          margin-top: 2.25rem;
           .expansion-placeholder {
             width: 100%;
             font-size: 0.9rem;

--- a/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.html
+++ b/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.html
@@ -3,7 +3,7 @@
 <mat-form-field class="overlay" [class.expanded]="resultsVisible" appearance="outline">
   <div class="search-box">
     <input matInput type="search" [placeholder]="placeholder" [formControl]="searchControl" #search>
-    <button class="add-button" [disabled]="!hasCheckedTags()" (click)="addTags(); search.focus()" matSuffix>
+    <button class="add-button" [class.active]="hasCheckedTags()" [disabled]="!hasCheckedTags()" (click)="addTags(); search.focus()" matSuffix>
       <mat-icon class="icon">add</mat-icon>
     </button>
   </div>

--- a/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.html
+++ b/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.html
@@ -3,7 +3,7 @@
 <mat-form-field class="overlay" [class.expanded]="resultsVisible" appearance="outline">
   <div class="search-box">
     <input matInput type="search" [placeholder]="placeholder" [formControl]="searchControl" #search>
-    <button class="add-button" [class.active]="hasCheckedTags()" [disabled]="!hasCheckedTags()" (click)="addTags(); search.focus()" matSuffix>
+    <button class="add-button" [class.active]="hasCheckedTags()" [disabled]="!hasCheckedTags()" (click)="addTags(); search.focus()" matSuffix #closeSearch>
       <mat-icon class="icon">add</mat-icon>
     </button>
   </div>

--- a/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.theme.scss
+++ b/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.theme.scss
@@ -29,6 +29,10 @@
 
     .add-button{
       background-color: transparent;
+
+      &.active {
+        background-color: mat-color($foreground, icons-hover);
+      }
       
       &:hover {
         background-color: mat-color($foreground, icons-hover);

--- a/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.ts
+++ b/projects/ccf-rui/src/app/shared/components/tag-search/tag-search.component.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input,
-  OnDestroy, Output,
+  OnDestroy, Output, ViewChild,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { bind as Bind } from 'bind-decorator';
@@ -46,6 +46,8 @@ export class TagSearchComponent implements OnDestroy {
 
   /** Emits when tags are added */
   @Output() readonly added = new EventEmitter<Tag[]>();
+
+  @ViewChild('closeSearch', { read: ElementRef, static: false }) closeSearch: ElementRef<HTMLElement>;
 
   /** Mapping for pluralizing the result total count */
   readonly countMapping = {
@@ -154,8 +156,9 @@ export class TagSearchComponent implements OnDestroy {
   @HostListener('window:click', ['$event']) // eslint-disable-line
   @HostListener('window:focusin', ['$event']) // eslint-disable-line
   closeResults(event: Event): void {
+    const { closeSearch } = this;
     if (this.resultsVisible && event.target instanceof Node) {
-      if (!this.el.nativeElement.contains(event.target)) {
+      if (!this.el.nativeElement.contains(event.target) || closeSearch.nativeElement.contains(event.target)) {
         this.resultsVisible = false;
       }
     }

--- a/projects/ccf-rui/src/app/shared/components/visibility-menu/visibility-menu.component.scss
+++ b/projects/ccf-rui/src/app/shared/components/visibility-menu/visibility-menu.component.scss
@@ -16,6 +16,8 @@
     transform: scaleX(-1);
     cursor: pointer;
     transition: .6s;
+    position: absolute;
+    top: 3rem;
     
     &:hover {
       border-radius: 2px;

--- a/projects/ccf-shared/src/lib/components/organ-selector/organ-selector.component.scss
+++ b/projects/ccf-shared/src/lib/components/organ-selector/organ-selector.component.scss
@@ -46,6 +46,7 @@
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           height: 100%;
+          transition: .6s;
 
           .carousel-icon {
             text-align: center;


### PR DESCRIPTION
#568 

- Added hover states to carousel items
- Selecting AS tag now triggers a gray background on the + button
- Adding AS tag now returns the search area to default
- Adjusted scrollbars so that they don't appear when there are few items
- AS and CES refresh buttons no longer scroll with the items
- Minor adjustments to top drawer toggle button