### PR TITLE
Show confirmation dialog when leaving the site

### DIFF
--- a/projects/ccf-rui/src/app/app-web-component.component.ts
+++ b/projects/ccf-rui/src/app/app-web-component.component.ts
@@ -56,7 +56,8 @@ const CONFIG_INPUT_PARSERS: Record<string, InputParser> = {
   editRegistration: parseJson,
   register: parseFunction,
   cancelRegistration: parseFunction,
-  fetchPreviousRegistrations: parseFunction
+  fetchPreviousRegistrations: parseFunction,
+  skipUnsavedChangesConfirmation: parseBoolean
 };
 
 
@@ -74,6 +75,7 @@ export class AppWebComponentComponent implements OnInit, OnChanges {
   @Input() register: string | RegistrationCallback;
   @Input() cancelRegistration: string | CancelRegistrationCallback;
   @Input() fetchPreviousRegistrations: string | FetchPreviousRegistrationsCallback;
+  @Input() skipUnsavedChangesConfirmation: string | boolean;
 
   initialized = false;
   changes: SimpleChanges = {};

--- a/projects/ccf-rui/src/app/core/services/config/config.ts
+++ b/projects/ccf-rui/src/app/core/services/config/config.ts
@@ -24,6 +24,8 @@ export interface GlobalConfig {
   registrationStarted?: boolean;
 
   cancelRegistration?: () => void;
+
+  skipUnsavedChangesConfirmation?: boolean;
 }
 
 declare global {

--- a/projects/ccf-rui/src/app/core/store/anatomical-structure-tags/anatomical-structure-tags.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/anatomical-structure-tags/anatomical-structure-tags.state.spec.ts
@@ -5,6 +5,7 @@ import { GlobalConfigState } from 'ccf-shared';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 
+import { PageState } from '../page/page.state';
 import { GLOBAL_CONFIG } from './../../services/config/config';
 import { ModelState } from './../model/model.state';
 import { SceneState } from './../scene/scene.state';
@@ -32,6 +33,12 @@ describe('AnatomicalStructureTagsState', () => {
         {
           provide: GLOBAL_CONFIG,
           useValue: {}
+        },
+        {
+          provide: PageState,
+          useValue: {
+            setHasChanges: () => undefined
+          }
         }
       ]
     });

--- a/projects/ccf-rui/src/app/core/store/anatomical-structure-tags/anatomical-structure-tags.state.ts
+++ b/projects/ccf-rui/src/app/core/store/anatomical-structure-tags/anatomical-structure-tags.state.ts
@@ -11,6 +11,7 @@ import { map } from 'rxjs/operators';
 
 import { Tag, TagId, TagSearchResult } from '../../models/anatomical-structure-tag';
 import { ModelState } from '../model/model.state';
+import { PageState } from '../page/page.state';
 import { SceneState } from '../scene/scene.state';
 
 
@@ -75,6 +76,8 @@ export class AnatomicalStructureTagState extends NgxsDataEntityCollectionsReposi
   /** Reference to the scene state */
   private scene: SceneState;
 
+  private page: PageState;
+
   /**
    * Creates an instance of scene state.
    *
@@ -96,10 +99,13 @@ export class AnatomicalStructureTagState extends NgxsDataEntityCollectionsReposi
     // Lazy load here
     this.model = this.injector.get(ModelState);
     this.scene = this.injector.get(SceneState);
+    this.page = this.injector.get(PageState);
 
     this.tags$.subscribe((tags) => {
       this._latestTags = tags;
     });
+
+    this.entities$.subscribe(() => this.page.setHasChanges());
   }
 
   @DataAction()

--- a/projects/ccf-rui/src/app/core/store/model/model.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/model/model.state.spec.ts
@@ -7,6 +7,7 @@ import { take } from 'rxjs/operators';
 
 import { ExtractionSet } from '../../models/extraction-set';
 import { VisibilityItem } from '../../models/visibility-item';
+import { PageState } from '../page/page.state';
 import { ReferenceDataState } from '../reference-data/reference-data.state';
 import { GLOBAL_CONFIG, GlobalConfig } from './../../services/config/config';
 import { ModelState, SlicesConfig, ViewSide, ViewType, XYZTriplet } from './model.state';
@@ -49,6 +50,12 @@ describe('ModelState', () => {
         {
           provide: GLOBAL_CONFIG,
           useValue: mockGlobalConfig
+        },
+        {
+          provide: PageState,
+          useValue: {
+            setHasChanges: () => undefined
+          }
         }
       ]
     });

--- a/projects/ccf-rui/src/app/core/store/model/model.state.ts
+++ b/projects/ccf-rui/src/app/core/store/model/model.state.ts
@@ -5,8 +5,8 @@ import { State } from '@ngxs/store';
 import { ALL_ORGANS, GlobalConfigState, OrganInfo } from 'ccf-shared';
 import { filterNulls } from 'ccf-shared/rxjs-ext/operators';
 import { sortBy } from 'lodash';
-import { EMPTY } from 'rxjs';
-import { debounceTime, delay, pluck, switchMap, take, tap } from 'rxjs/operators';
+import { EMPTY, Observable } from 'rxjs';
+import { debounceTime, delay, distinctUntilChanged, mapTo, pluck, switchMap, take, tap } from 'rxjs/operators';
 
 import { ExtractionSet } from '../../models/extraction-set';
 import { VisibilityItem } from '../../models/visibility-item';
@@ -143,6 +143,26 @@ export class ModelState extends NgxsImmutableDataRepository<ModelStateModel> {
   readonly anatomicalStructures$ = this.state$.pipe(pluck('anatomicalStructures'));
   /** Extraction sets observable */
   readonly extractionSets$ = this.state$.pipe(pluck('extractionSets'));
+
+  @Computed()
+  get modelChanged$(): Observable<void> {
+    const ignoredKeys = ['viewType', 'viewSide', 'showPrevious'];
+    const keys = Object.keys(this.initialState)
+      .filter(key => !ignoredKeys.includes(key));
+
+    return this.state$.pipe(
+      distinctUntilChanged((v1, v2) => {
+        for (const key of keys) {
+          if (v1[key] !== v2[key]) {
+            return false;
+          }
+        }
+
+        return true;
+      }),
+      mapTo(undefined)
+    );
+  }
 
   /** Reference to the reference data state */
   private referenceData: ReferenceDataState;

--- a/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
@@ -2,10 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { NgxsDataPluginModule } from '@ngxs-labs/data';
 import { NgxsModule, Store } from '@ngxs/store';
 import { GlobalConfigState } from 'ccf-shared';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import { GLOBAL_CONFIG } from '../../services/config/config';
+import { AnatomicalStructureTagState } from '../anatomical-structure-tags/anatomical-structure-tags.state';
 import { ModelState } from './../model/model.state';
 import { PageState } from './page.state';
 
@@ -22,12 +23,13 @@ describe('PageState', () => {
     TestBed.configureTestingModule({
       imports: [
         NgxsDataPluginModule.forRoot(),
-        NgxsModule.forRoot([PageState, ModelState, GlobalConfigState])
+        NgxsModule.forRoot([PageState, ModelState, AnatomicalStructureTagState, GlobalConfigState])
       ],
       providers: [
         ModelState,
+        AnatomicalStructureTagState,
         GlobalConfigState,
-        { provide: GLOBAL_CONFIG, useValue: {} },
+        { provide: GLOBAL_CONFIG, useValue: {} }
       ]
     });
 
@@ -39,13 +41,13 @@ describe('PageState', () => {
         },
         useCancelRegistrationCallback: false
       },
-      globalConfig: {}
+      globalConfig: {
+        skipUnsavedChangesConfirmation: true
+      }
     });
 
     state = TestBed.inject(PageState);
     state.ngxsOnInit();
-
-    (window as unknown as Record<string, unknown>).skipUnsavedChangesConfirmation = true;
   });
 
   it('has the latest user', async () => {

--- a/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { NgxsDataPluginModule } from '@ngxs-labs/data';
 import { NgxsModule, Store } from '@ngxs/store';
 import { GlobalConfigState } from 'ccf-shared';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import { GLOBAL_CONFIG } from '../../services/config/config';

--- a/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/page/page.state.spec.ts
@@ -27,7 +27,7 @@ describe('PageState', () => {
       providers: [
         ModelState,
         GlobalConfigState,
-        { provide: GLOBAL_CONFIG, useValue: {} }
+        { provide: GLOBAL_CONFIG, useValue: {} },
       ]
     });
 
@@ -44,6 +44,8 @@ describe('PageState', () => {
 
     state = TestBed.inject(PageState);
     state.ngxsOnInit();
+
+    (window as unknown as Record<string, unknown>).skipUnsavedChangesConfirmation = true;
   });
 
   it('has the latest user', async () => {

--- a/projects/ccf-rui/src/app/core/store/registration/registration.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/registration/registration.state.spec.ts
@@ -44,7 +44,8 @@ const testPage: Immutable<PageStateModel> = {
   registrationStarted: false,
   useCancelRegistrationCallback: false,
   registrationCallbackSet: false,
-  skipConfirmation: true
+  skipConfirmation: true,
+  hasChanges: false
 };
 
 function nextValue<T>(obs: Observable<T>): Promise<T> {
@@ -120,7 +121,7 @@ describe('RegistrationState', () => {
           provide: PageState, useValue: {
             state$: pageStateSubject,
             snapshot: initialPageState,
-            setSkipConfirmation: () => undefined
+            clearHasChanges: () => undefined
           }
         },
         {

--- a/projects/ccf-rui/src/app/core/store/registration/registration.state.spec.ts
+++ b/projects/ccf-rui/src/app/core/store/registration/registration.state.spec.ts
@@ -43,7 +43,8 @@ const testPage: Immutable<PageStateModel> = {
   },
   registrationStarted: false,
   useCancelRegistrationCallback: false,
-  registrationCallbackSet: false
+  registrationCallbackSet: false,
+  skipConfirmation: true
 };
 
 function nextValue<T>(obs: Observable<T>): Promise<T> {
@@ -118,7 +119,8 @@ describe('RegistrationState', () => {
         {
           provide: PageState, useValue: {
             state$: pageStateSubject,
-            snapshot: initialPageState
+            snapshot: initialPageState,
+            setSkipConfirmation: () => undefined
           }
         },
         {

--- a/projects/ccf-rui/src/app/core/store/registration/registration.state.ts
+++ b/projects/ccf-rui/src/app/core/store/registration/registration.state.ts
@@ -267,7 +267,7 @@ export class RegistrationState extends NgxsImmutableDataRepository<RegistrationS
 
     this.addRegistration(jsonObj);
     this.setDisplayErrors(false);
-    this.page.setSkipConfirmation(true);
+    this.page.clearHasChanges();
   }
 
   /**

--- a/projects/ccf-rui/src/app/core/store/registration/registration.state.ts
+++ b/projects/ccf-rui/src/app/core/store/registration/registration.state.ts
@@ -267,6 +267,7 @@ export class RegistrationState extends NgxsImmutableDataRepository<RegistrationS
 
     this.addRegistration(jsonObj);
     this.setDisplayErrors(false);
+    this.page.setSkipConfirmation(true);
   }
 
   /**

--- a/projects/ccf-rui/src/environments/environment.prod.ts
+++ b/projects/ccf-rui/src/environments/environment.prod.ts
@@ -10,5 +10,6 @@ export const environment = {
     hubmapAssetsUrl: 'https://assets.hubmapconsortium.org',
     hubmapToken: localStorage.getItem('HUBMAP_TOKEN') ?? ''
   },
+  skipUnsavedChangesConfirmation: false,
   googleAnalyticsToken: window.location.hostname === 'portal.hubmapconsortium.org' ? 'G-1WRJHN9FM6' : 'G-J9HWV9QPJ4'
 };

--- a/projects/ccf-rui/src/environments/environment.staging.ts
+++ b/projects/ccf-rui/src/environments/environment.staging.ts
@@ -10,5 +10,6 @@ export const environment = {
     hubmapAssetsUrl: 'https://assets.hubmapconsortium.org',
     hubmapToken: localStorage.getItem('HUBMAP_TOKEN') ?? ''
   },
+  skipUnsavedChangesConfirmation: false,
   googleAnalyticsToken: 'G-ERNVZ1Q4KE'
 };

--- a/projects/ccf-rui/src/environments/environment.ts
+++ b/projects/ccf-rui/src/environments/environment.ts
@@ -14,6 +14,7 @@ export const environment = {
     hubmapAssetsUrl: 'https://assets.hubmapconsortium.org',
     hubmapToken: localStorage.getItem('HUBMAP_TOKEN') ?? ''
   },
+  skipUnsavedChangesConfirmation: true,
   googleAnalyticsToken: 'G-B3DT7XPMRT'
 };
 


### PR DESCRIPTION
Feature can be enabled/disabled either through the environment file or setting `skipUnsavedChangesConfirmation` on `window`