### PR TITLE
Changed Common Extraction Sites to Landmarks for semantic unity

### DIFF
--- a/projects/ccf-rui/src/app/modules/left-sidebar/left-sidebar.component.html
+++ b/projects/ccf-rui/src/app/modules/left-sidebar/left-sidebar.component.html
@@ -28,8 +28,8 @@
 
         <mat-expansion-panel class="extraction-menu" [expanded]="modalClosed">
             <mat-expansion-panel-header class="expansion-header">
-                <mat-panel-title matTooltip="Some organs have predefined extraction sites--you can turn these on/off."
-                    class="expansion-title">Common Extraction Sites</mat-panel-title>
+                <mat-panel-title matTooltip="Some organs have predefined landmarks--you can turn these on/off."
+                    class="expansion-title">Landmarks</mat-panel-title>
             </mat-expansion-panel-header>
             <div *ngIf="organSelected$ | async" class="expansion-content">
                 <ccf-extraction-set-dropdown [sets]="model.extractionSets$ | async"

--- a/projects/ccf-rui/src/app/modules/right-sidebar/right-sidebar.component.html
+++ b/projects/ccf-rui/src/app/modules/right-sidebar/right-sidebar.component.html
@@ -1,8 +1,8 @@
 <div class="scroll-wrapper">
-  
+
   <div class="container">
     <div class='info-button-container'>
-      <ccf-info-button videoID="ftmAn_XhafY" infoTitle="HuBMAP CCF Registration User Interface"></ccf-info-button>
+      <ccf-info-button videoID="v9ht5S7MVc0" infoTitle="HuBMAP CCF Registration User Interface"></ccf-info-button>
     </div>
     <ccf-block-size-input [blockSize]="model.blockSize$ | async" (blockSizeChange)="model.setBlockSize($event)">
     </ccf-block-size-input>

--- a/projects/ccf-rui/src/app/shared/components/extraction-set-dropdown/extraction-set-dropdown.component.html
+++ b/projects/ccf-rui/src/app/shared/components/extraction-set-dropdown/extraction-set-dropdown.component.html
@@ -1,5 +1,5 @@
 <mat-form-field class="dropdown-form-field" *ngIf="isMultiple()" appearance="fill">
-  <mat-label class="extraction-dropdown-label">Extraction Set</mat-label>
+  <mat-label class="extraction-dropdown-label">Landmark Set</mat-label>
   <mat-select disableOptionCentering=true (selectionChange)="extractionSetChanged($event.value)" [value]="sets[0]" panelClass="extraction-set-panel">
     <mat-option class="extraction-set-options" *ngFor="let set of sets" [value]='set'>
       {{set.name}} ({{set.sites.length}})


### PR DESCRIPTION
As discussed in email exchange on Tue, 12/7/21, with @bherr2. The change is purely on the HTML level inside two templates. A screenshot is farther below. 

![image](https://user-images.githubusercontent.com/22821046/145110459-747bc2fc-8db0-4372-9b97-4fd73ab724a1.png)
