### PR TITLE
Pbi 1148 Custom font family

### DIFF
--- a/projects/ccf-eui/src/styles.scss
+++ b/projects/ccf-eui/src/styles.scss
@@ -129,7 +129,7 @@ body {
 body {
   margin: 0;
   padding: 0;
-  font-family: Inter, Inter Variable, sans-serif;
+  font-family: var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif;
   background-color: white;
 }
 
@@ -138,7 +138,7 @@ mat-icon {
 }
 
 button {
-  font-family: Inter, Inter Variable, sans-serif;
+  font-family: var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif;
   font-size: 14px;
   font-weight: 500;
 }

--- a/projects/ccf-eui/src/themes/common/_typography.scss
+++ b/projects/ccf-eui/src/themes/common/_typography.scss
@@ -3,5 +3,5 @@
 
 $config: mat.define-legacy-typography-config(
   $body-1: mat.define-typography-level(1rem, 1.5rem, 500),
-  $font-family: 'Inter, Inter Variable, sans-serif'
+  $font-family: 'var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif'
 );

--- a/projects/ccf-organ-info/src/app/app.component.scss
+++ b/projects/ccf-organ-info/src/app/app.component.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: row;
   padding: 1rem;
-  font-family: Inter, Inter Variable, sans-serif;
+  font-family: var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif;
   font-size: 0.95rem;
   line-height: 1.5;
   text-align: left;

--- a/projects/ccf-organ-info/src/app/modules/link-cards/link-cards.component.scss
+++ b/projects/ccf-organ-info/src/app/modules/link-cards/link-cards.component.scss
@@ -71,6 +71,6 @@
   border-radius: 2px;
   line-height: 2.75;
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  font-family: Inter, Inter Variable, Helvetica, Arial, sans-serif;
+  font-family: var(--ccf-ui-font, ""), Inter, Inter Variable, Helvetica, Arial, sans-serif;
 
 }

--- a/projects/ccf-rui/src/styles.scss
+++ b/projects/ccf-rui/src/styles.scss
@@ -119,7 +119,7 @@ body {
 body {
   margin: 0;
   padding: 0;
-  font-family: Inter, Inter Variable, sans-serif;
+  font-family: var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif;
   background-color: white;
 }
 

--- a/projects/ccf-rui/src/themes/common/_typography.scss
+++ b/projects/ccf-rui/src/themes/common/_typography.scss
@@ -3,5 +3,5 @@
 
 $config: mat.define-legacy-typography-config(
   $body-1: mat.define-typography-level(1rem, 1.5rem, 500),
-  $font-family: 'Inter, Inter Variable, sans-serif'
+  $font-family: 'var(--ccf-ui-font, ""), Inter, Inter Variable, sans-serif'
 );


### PR DESCRIPTION
Enable embedders to customize which font family is used throughout the ui by setting the `--ccf-ui-font` css property.
If not set the ui will default to using Inter, Inter Variable, or sans-serif whichever is available.

Closes #1148 